### PR TITLE
Allow Ctrl-D to exit

### DIFF
--- a/lib/src/kernel.dart
+++ b/lib/src/kernel.dart
@@ -50,7 +50,17 @@ Future<Null> runRepl(SandboxIsolate sandboxIsolate) async {
     while (true) {
       stdout.write('>>> ');
 
-      final input = stdin.readLineSync();
+      var input;
+      try {
+        input = stdin.readLineSync();
+      } on StdinException catch (e) {
+        input = null;
+      }
+
+      if (input == null) {
+        exit(0);
+      }
+
       if (input.isEmpty) {
         continue;
       }


### PR DESCRIPTION
...without a long traceback, that is!